### PR TITLE
Carve out special perms for podling role accounts

### DIFF
--- a/gen.py
+++ b/gen.py
@@ -246,6 +246,16 @@ class Generator:
             if p in COMMITTERS_MAY_RELEASE:
                 content.append(f'@{p} = rw')
 
+            # Podling role accounts would normally require incubator r/w, but we will carve out special perms here
+            if p in CI_MAY_STAGE:
+                content.extend([
+                    '',
+                    '# project role accounts also extend to /dev/incubator/$project',
+                    f'[/dev/incubator/{p}]',
+                    f'svc_dist_{p} = rw',
+                ])
+            
+
         content.append(DIST_EPILOGUE)
         atomic_write(output, '\n'.join(content))
 


### PR DESCRIPTION
Role accounts for podlings will not work by default, as they govern /dev/$project when /dev/incubator/$project is needed. This will add an additional permission for that space for role accounts. When graduating, projects will then move on to use the existing perms for /dev/$project which is specified in the previous role account logic, so the move should be seamless.