### PR TITLE
Detect missing attribute early.

### DIFF
--- a/gen.py
+++ b/gen.py
@@ -97,6 +97,8 @@ class LDAPClient:
                 members = data['memberUid']
             elif 'member' in data:
                 members = data['member']
+            else:
+                raise KeyError(f"LDAP group cn={cn} does not have memberUid or member attribute, possibly corrupted/malformed in LDAP.")
         else:
             if attr in data:
                 members = data[attr]


### PR DESCRIPTION
Would otherwise fail with the unhelpful message:
UnboundLocalError: cannot access local variable 'members' where it is not associated with a value