### PR TITLE
Remove 'abdera' and 'trafficcontrol' from committers may release

### DIFF
--- a/gen.py
+++ b/gen.py
@@ -35,7 +35,6 @@ SVN_ADMINS = 'gmcdonald,humbedooh,cml,dfoulks,wells,reanguiano,bthomson'
 # Some projects allow committers to make releases.
 ### should cross-check this list against Attic
 COMMITTERS_MAY_RELEASE = {
-    'abdera',
     'bookkeeper',
     'calcite',
     'camel',
@@ -45,7 +44,6 @@ COMMITTERS_MAY_RELEASE = {
     'hive',
     'lucene',
     'solr',
-    'trafficcontrol',
     'zookeeper',
     }
 

--- a/gen.py
+++ b/gen.py
@@ -34,6 +34,7 @@ SVN_ADMINS = 'gmcdonald,humbedooh,cml,dfoulks,wells,reanguiano,bthomson'
 ### also, for config
 # Some projects allow committers to make releases.
 ### should cross-check this list against Attic
+# Please adjust ATR's copy: https://github.com/apache/tooling-trusted-releases/blob/main/atr/registry.py
 COMMITTERS_MAY_RELEASE = {
     'bookkeeper',
     'calcite',


### PR DESCRIPTION
On review these two are in the attic. Abdera in Feb 2017 and Traffic Control in Oct 2025